### PR TITLE
feat: add annotations support for service (sticky session)

### DIFF
--- a/charts/libretranslate/templates/service.yaml
+++ b/charts/libretranslate/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "libretranslate.fullname" . }}
   labels:
     {{- include "libretranslate.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/libretranslate/values.yaml
+++ b/charts/libretranslate/values.yaml
@@ -35,6 +35,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 5000
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
I finally find the good solution for sticky session and traefik, and I need to add those annotations on the service, not the ingress :-)
This should be the same with nginx or other ingress.

```
annotations:
    traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
    traefik.ingress.kubernetes.io/service.sticky.cookie.name: translate
```

Can you cut a release then ? 

Thanks !